### PR TITLE
rake.yml template: add explicit permissions: contents: read: https://github.com/metanorma/cimas/issues/40

### DIFF
--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -2,6 +2,9 @@
 # See https://github.com/metanorma/cimas
 name: rake
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master, main ]


### PR DESCRIPTION
## Summary

Per https://github.com/metanorma/cimas/issues/40, adds explicit `permissions: contents: read` to the `rake.yml` workflow template so target repos no longer need per-repo hand-edits.

Mirrors the intent that was hand-applied in [metanorma/metanorma-plugin-datastruct@066c51e](https://github.com/metanorma/metanorma-plugin-datastruct/commit/066c51e) into the template, so the explicit-permissions practice propagates to every plugin/gem repo via `cimas` regeneration.

## Dependency

This depends on https://github.com/metanorma/ci/pull/277 (revert of `30a34e4` in `metanorma/ci`) landing first. While `generic-rake.yml@main` still has `tests-passed` declaring `permissions: contents: write` at the job level, capping the caller at `contents: read` causes static validation failures. Once that revert lands, this template change is safe to deploy.

## Test plan

- [ ] After this PR and https://github.com/metanorma/ci/pull/277 merge: run `cimas` against `metanorma-plugin-datastruct` and confirm the regenerated `.github/workflows/rake.yml` contains the new `permissions: contents: read` block and the workflow is valid.

cc @ronaldtse
