### PR TITLE
Add ostruct as explicit dependency for Ruby 4.0+ compat

### DIFF
--- a/cimas.gemspec
+++ b/cimas.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "travis"
   spec.add_dependency "octokit"
   spec.add_dependency "git"
+  spec.add_dependency "ostruct"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
Adds `ostruct` as an explicit runtime dependency. Required for Ruby 4.0+ where ostruct is no longer a default gem; without it, `lib/cimas/cli/command.rb:7`'s `require 'ostruct'` fails on Ruby 4.0.x with `cannot load such file -- ostruct (LoadError)`, making the cimas CLI unusable on current Ruby.

## Test plan

- [ ] `bundle install` resolves ostruct as a dependency
- [ ] `bundle exec cimas help` runs to completion on Ruby 4.0.5 (verified locally; produces the cimas help text without LoadError)

## Note in passing

A separate `faraday-retry` warning ("To use retry middleware with Faraday v2.0+, install `faraday-retry` gem") surfaces on the same Ruby version. That's a non-blocking degraded-behaviour warning, not an error — left for a follow-up.

🤖
