### PR TITLE
Restore cimas CI: relax bundler constraint + drop unused travis dep

### DIFF
--- a/cimas.gemspec
+++ b/cimas.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "travis"
   spec.add_dependency "octokit"
   spec.add_dependency "git"
   spec.add_dependency "ostruct"

--- a/cimas.gemspec
+++ b/cimas.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "git"
   spec.add_dependency "ostruct"
 
-  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -5,7 +5,6 @@ require 'git'
 require_relative '../repository'
 require 'octokit'
 require 'ostruct'
-# require 'travis/client/session'
 
 module Cimas
   module Cli
@@ -356,8 +355,6 @@ module Cimas
           end
         end
 
-        # do two separate `git add` because one of it may be missing
-        # run_cmd("git -C #{repos_path} multi -c add .travis.yml", dry_run)
         # run_cmd("git -C #{repos_path} multi -c add appveyor.yml")
       end
 


### PR DESCRIPTION
Two compat fixes in one PR so cimas CI returns to green across all matrix Rubies.

## Commits

1. **Relax bundler dev-dep from `~> 2.0` to `>= 2.0`** — runner default bundler is now 4.0.x; the `~> 2.0` constraint rejected it, breaking PR rake CI since the runner image upgrade.
2. **Drop unused `travis` dependency** — pulls in `json_pure 2.6.3` transitively, which references `JSON::Fragment` (removed in Ruby 4.0 stdlib). Breaks every Ruby 4.0 rake job at spec_helper load. The travis gem is dead code in cimas: the only `lib/` references were two commented-out lines from the pre-GHA migration. Removed those too.

## Diagnosis chain

```
version solving has failed (bundler ~> 2.0 vs runner default 4.0.x)
  → fixed by commit 1
NameError: uninitialized constant JSON::Fragment
  (vendor/bundle/.../json_pure-2.6.3/lib/json/ext.rb)
  → fixed by commit 2 (drops travis → drops json_pure)
```

## Test plan

- [x] Commit 1 turned Ruby 3.3 + 3.4 all-OS jobs green
- [ ] Commit 2 expected to turn Ruby 4.0 all-OS jobs green

🤖
