### PR TITLE
setup: enable per-repo auto-delete-on-merge so wave branches clean up natively

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -72,6 +72,38 @@ module Cimas
           else
             puts "Skip cloning #{repo_name}, #{repo_dir} already exists."
           end
+
+          enable_auto_delete_on_merge(repo_name, attribs['remote'])
+        end
+      end
+
+      # Enable GitHub's "Automatically delete head branches" repo setting so
+      # merged PR branches (cimas-sync waves and otherwise) are removed by
+      # GitHub natively. Idempotent — setting it on a repo where it's already
+      # true is a no-op. Token-gated: if no GitHub token is configured, skip
+      # with a warning. Permission-gated: failures (403, 404) are logged but
+      # do not abort setup, since some repos in a cimas workspace may not
+      # grant the caller admin scope.
+      def enable_auto_delete_on_merge(repo_name, remote)
+        if config['github_token'].to_s.empty?
+          # First non-tokened skip emits the explanation; subsequent ones stay quiet.
+          unless @auto_delete_warned_no_token
+            puts "[WARNING] No github_token configured; skipping auto-delete-on-merge setup for all repos."
+            @auto_delete_warned_no_token = true
+          end
+          return
+        end
+
+        slug = git_remote_to_github_name(remote)
+        begin
+          github_client.edit_repository(slug, delete_branch_on_merge: true)
+          puts "  [auto-delete-on-merge enabled] #{slug}"
+        rescue Octokit::NotFound
+          puts "  [WARNING] auto-delete-on-merge: #{slug} not found via the configured token"
+        rescue Octokit::Forbidden, Octokit::Unauthorized
+          puts "  [WARNING] auto-delete-on-merge: insufficient permissions on #{slug}"
+        rescue Octokit::Error => e
+          puts "  [WARNING] auto-delete-on-merge: #{slug} failed (#{e.class}): #{e.message}"
         end
       end
 


### PR DESCRIPTION
Refs https://github.com/metanorma/ogc-wfs/pull/29#issuecomment-4789...

## Summary

Adds a per-repo "Automatically delete head branches" enable to `cimas setup`. After `cimas setup` runs against a workspace, every repo in the config has GitHub's native auto-delete-on-merge setting turned on, so head branches (cimas-sync waves and otherwise) are removed automatically by GitHub on every merge. No cimas-side chase logic needed, no per-wave cleanup pass needed.

Triggered by @ronaldtse's request after the 2026-06-24 cimas sync wave left ~99 branches on origin that needed a manual cleanup. The cleanup itself was already done by hand tonight (127 branches deleted in one shot); this PR is the forward-fix so future waves don't accumulate the same pollution.

## Implementation

New private method `enable_auto_delete_on_merge(repo_name, remote)` called once per repo from `setup`. The method:

1. Resolves the GitHub slug from the configured remote via the existing `git_remote_to_github_name` helper.
2. Calls `github_client.edit_repository(slug, delete_branch_on_merge: true)` (Octokit). The GitHub API field is idempotent — setting it to `true` when it's already `true` is a no-op.
3. Logs the result per-repo.

Token-gated: if `config['github_token']` is empty, prints one banner warning and skips on every subsequent repo. Cloning still works without a token — only the auto-delete enable is skipped.

Permission-gated: `Octokit::Forbidden`, `Octokit::Unauthorized`, `Octokit::NotFound` and other `Octokit::Error` subclasses are caught and logged as `[WARNING]`s rather than aborting `setup`. Some repos in a cimas workspace may not grant the caller admin scope (admin scope is what GitHub requires to PATCH the `delete_branch_on_merge` field); those repos are skipped with a clear warning and setup continues for the rest.

## Behavioural notes

- This is a **repo-wide** setting, not cimas-specific — once enabled, GitHub deletes the head branch on every merged PR in that repo, not just cimas-sync ones. That's the same behaviour the other major Ribose orgs already use (`relaton/`, `lutaml/`, etc. have it on most repos already) so this brings the metanorma org into convention parity.
- If the maintainer would prefer cimas-specific cleanup (delete only `cimas-sync-*` branches, leave other PR head branches alone), the right shape would be a separate post-merge cleanup subcommand rather than a repo-setting change; let me know and I'll repivot. The repo-setting approach is what I chose because it's GitHub-native, idempotent, and one-shot.

## Verification

Ran `bundle exec exe/cimas setup --help` — flags still parse cleanly, no breakage.

Did not run `cimas setup` end-to-end against the 187-repo workspace yet — that's a destructive-ish operation (mutates org-level settings on every repo in the config) and I'd prefer to land this in a PR-reviewed state before exercising it against production. Local syntax-check confirms `ruby -c lib/cimas/cli/command.rb` passes.

🤖
