### PR TITLE
open-prs: coerce assignees/reviewers to Array so CLI-flag strings work

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -408,8 +408,15 @@ module Cimas
         sanity_check
         branch = merge_branch
         message = pr_message
-        assignees = config['assignees']
-        reviewers = config['reviewers']
+        # Coerce to an Array of handles. Accepts:
+        #   - Array of strings from cimas.yml settings (the legacy shape)
+        #   - String from the `-a` / `-w` CLI flags (a single handle, OR a
+        #     comma-separated list per the option's help text)
+        # Without coercion, `-a opoudjis` reached this block as a bare String
+        # and `.join(',')` further down crashed with NoMethodError, aborting
+        # `cimas open-prs` before any PR could be created.
+        assignees = Array(config['assignees']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
+        reviewers = Array(config['reviewers']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
         cooldown_count = config['cooldown_count']
         cooldown_time = config['cooldown_time']
 


### PR DESCRIPTION
## Summary

`cimas open-prs -a opoudjis` (or `-w <handle>`) currently aborts with `NoMethodError: undefined method 'join' for an instance of String` before opening any PR. Discovered while running the 2026-06-24 cimas sync wave from `metanorma/ci/cimas-config/cimas.yml`.

## Root cause

In `Cimas::Cli::Command#open_prs`:

```ruby
assignees = config['assignees']
reviewers = config['reviewers']
```

`config['assignees']` and `config['reviewers']` come from two distinct sources:

- `cimas.yml`'s `settings.assignees` / `settings.reviewers` blocks (a YAML array of handles → an `Array<String>` after parse).
- The CLI `-a ASSIGNMENTS` / `-w REVIEWERS` flags, whose option-parser handler stores the raw value as a `String` (per the option help text, it may itself be a comma-separated list of handles).

Downstream in the same method, both values are passed through `.join(',')` for log output and to `github_client.add_assignees(slug, number, assignees)`. The `.join` call expects an `Array` and raises on a `String`, aborting `open_prs` before any PR can be created.

## Fix

Coerce both values to an `Array<String>` at the top of `open_prs`, handling both the legacy YAML-array shape and the CLI-flag string shape (including the comma-separated case):

```ruby
assignees = Array(config['assignees']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
reviewers = Array(config['reviewers']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
```

- `Array(...)` lifts a single string into a one-element array, leaves arrays unchanged, and returns `[]` for `nil`.
- `.flat_map { |x| x.is_a?(String) ? x.split(',') : x }` then splits any string element on `,`, so `"opoudjis,andrew2net"` becomes `["opoudjis", "andrew2net"]`. Non-string array elements (none expected from real configs, but defensive) are kept as-is.

`.join`, `.empty?`, and the eventual `Octokit::Client#add_assignees(slug, number, assignees)` all now operate on a clean `Array<String>` regardless of input shape.

## Verification

Ruby syntax check (`ruby -c lib/cimas/cli/command.rb`) passes. Verified end-to-end during the 2026-06-24 wave: with this patch applied locally, `cimas open-prs -a opoudjis -f .../cimas.yml -r .../cimas-wd-2026-06-15 -b cimas-sync-2026-06-24 -m "..."` opened 99 PRs across the 187-repo workspace without the prior `NoMethodError`.

🤖
