### PR TITLE
Replace setup-time auto-delete-on-merge with cleanup-merged-prs subcommand

### DIFF
--- a/exe/cimas
+++ b/exe/cimas
@@ -13,13 +13,14 @@ options = {
 
 top_help = <<HELP
 Commonly used command are:
-   setup:     do clone all repos
-   pull :     do pull for repos
-   sync :     do update ci configurations for all repos described in config
-   diff :     show diff for all repos
-   push :     do push changes to repote server
-   open-prs : do PR for Github with hub utility
-   for-each : run command for each repo with conditions
+   setup:              do clone all repos
+   pull :              do pull for repos
+   sync :              do update ci configurations for all repos described in config
+   diff :              show diff for all repos
+   push :              do push changes to repote server
+   open-prs :          do PR for Github with hub utility
+   cleanup-merged-prs: delete wave branches whose PR has merged (run after merges land)
+   for-each :          run command for each repo with conditions
 See 'cimas COMMAND --help' for more information on a specific command.
 HELP
 
@@ -191,6 +192,25 @@ subcommands = {
 
     opts.on("-c SHELL_CMD", "--shell-cmd=CMD", "Command to execute") do |shell_cmd|
       options['shell_cmd'] = shell_cmd
+    end
+  end,
+  'cleanup-merged-prs' => OptionParser.new do |opts|
+    opts.banner = "Usage: cimas cleanup-merged-prs [options]"
+
+    opts.on("-r REPOS_PATH", "--repo-path=REPOS_PATH", "Repo root dir path") do |path|
+      options['repos_path'] = Pathname.getwd + path
+    end
+
+    opts.on("-f CONFIG_FILE_PATH", "--config-path=CONFIG_FILE_PATH", "Config file path") do |path|
+      options['config_file_path'] = validate_config_path(Pathname.getwd + path)
+    end
+
+    opts.on("-b BRANCH", "--branch=BRANCH", "Wave branch to clean up (same as the -b push_to_branch used in `cimas push`)") do |branch|
+      options['push_to_branch'] = branch
+    end
+
+    opts.on("-g GROUP1,GROUP2,GROUPX", Array, "Groups to update") do |groups|
+      options['groups'] = groups
     end
   end,
 }

--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -72,38 +72,6 @@ module Cimas
           else
             puts "Skip cloning #{repo_name}, #{repo_dir} already exists."
           end
-
-          enable_auto_delete_on_merge(repo_name, attribs['remote'])
-        end
-      end
-
-      # Enable GitHub's "Automatically delete head branches" repo setting so
-      # merged PR branches (cimas-sync waves and otherwise) are removed by
-      # GitHub natively. Idempotent — setting it on a repo where it's already
-      # true is a no-op. Token-gated: if no GitHub token is configured, skip
-      # with a warning. Permission-gated: failures (403, 404) are logged but
-      # do not abort setup, since some repos in a cimas workspace may not
-      # grant the caller admin scope.
-      def enable_auto_delete_on_merge(repo_name, remote)
-        if config['github_token'].to_s.empty?
-          # First non-tokened skip emits the explanation; subsequent ones stay quiet.
-          unless @auto_delete_warned_no_token
-            puts "[WARNING] No github_token configured; skipping auto-delete-on-merge setup for all repos."
-            @auto_delete_warned_no_token = true
-          end
-          return
-        end
-
-        slug = git_remote_to_github_name(remote)
-        begin
-          github_client.edit_repository(slug, delete_branch_on_merge: true)
-          puts "  [auto-delete-on-merge enabled] #{slug}"
-        rescue Octokit::NotFound
-          puts "  [WARNING] auto-delete-on-merge: #{slug} not found via the configured token"
-        rescue Octokit::Forbidden, Octokit::Unauthorized
-          puts "  [WARNING] auto-delete-on-merge: insufficient permissions on #{slug}"
-        rescue Octokit::Error => e
-          puts "  [WARNING] auto-delete-on-merge: #{slug} failed (#{e.class}): #{e.message}"
         end
       end
 
@@ -572,6 +540,77 @@ module Cimas
               puts "Cool down for #{cooldown_time}sec to not abuse GitHub API..."
               sleep(cooldown_time)
             end
+          end
+        end
+      end
+
+      # Per-wave local cleanup: delete the branch named by `push_to_branch`
+      # from each target repo on origin IF the corresponding PR has merged.
+      # Open PRs are left alone (their branch is still in use). Branches with
+      # no PR are deleted too (a wave that opened no PR for the repo, e.g.
+      # because cimas detected "no commits" at push time, leaves a stale
+      # branch on origin we shouldn't keep). Requires only standard `repo`
+      # scope on each target repo — no admin scope, since branch deletion
+      # against a merged PR is a push-level operation.
+      def cleanup_merged_prs
+        sanity_check
+        branch = push_to_branch
+
+        filtered_repo_names.each do |repo_name|
+          repo = repo_by_name(repo_name)
+          if repo.nil?
+            puts "[WARNING] #{repo_name} not configured, skipping."
+            next
+          end
+
+          github_slug = git_remote_to_github_name(repo.remote)
+          owner = github_slug.split('/').first
+
+          begin
+            prs = github_client.pull_requests(
+              github_slug,
+              head: "#{owner}:#{branch}",
+              state: 'all'
+            )
+          rescue Octokit::Error => e
+            puts "[ERROR] #{github_slug}: PR lookup failed (#{e.class}): #{e.message}"
+            next
+          end
+
+          pr = prs.first
+
+          if pr.nil?
+            # No PR for this branch — attempt to delete if the branch exists
+            dry_run("Delete branch #{github_slug}:#{branch} (no PR found)") do
+              begin
+                github_client.delete_branch(github_slug, branch)
+                puts "[deleted-no-pr] #{github_slug}:#{branch}"
+              rescue Octokit::UnprocessableEntity, Octokit::NotFound
+                puts "[absent] #{github_slug}:#{branch} (already deleted)"
+              rescue Octokit::Error => e
+                puts "[ERROR] #{github_slug}:#{branch} delete failed (#{e.class}): #{e.message}"
+              end
+            end
+            next
+          end
+
+          if pr.merged_at
+            dry_run("Delete branch #{github_slug}:#{branch} (PR ##{pr.number} merged)") do
+              begin
+                github_client.delete_branch(github_slug, branch)
+                puts "[deleted-merged] #{github_slug}:#{branch} (PR ##{pr.number})"
+              rescue Octokit::UnprocessableEntity, Octokit::NotFound
+                puts "[absent] #{github_slug}:#{branch} (PR ##{pr.number} merged but branch already gone)"
+              rescue Octokit::Error => e
+                puts "[ERROR] #{github_slug}:#{branch} delete failed (#{e.class}): #{e.message}"
+              end
+            end
+          elsif pr.state == 'open'
+            puts "[skip-open] #{github_slug}:#{branch} (PR ##{pr.number} still open)"
+          else
+            # Closed-without-merge — keep branch by default; closing without merge
+            # often means someone intends to revisit. Operator can clean up manually.
+            puts "[skip-closed] #{github_slug}:#{branch} (PR ##{pr.number} closed without merge)"
           end
         end
       end


### PR DESCRIPTION
Refs https://github.com/metanorma/cimas/pull/45
Refs https://github.com/metanorma/ci/issues/304

## Summary

Reverses the architectural choice in [`#45`](https://github.com/metanorma/cimas/pull/45) and replaces it with a per-wave cleanup operation.

- **Removes** `enable_auto_delete_on_merge` from `cimas setup` and its supporting method. That approach was the wrong shape: it required admin scope on every cimas-managed repo (which @opoudjis doesn't have on most of them — proven by the 1-of-187-success rate during yesterday's trial), and it changed the **repo-wide GitHub default** behaviour for every PR author in those repos, not just cimas waves. Both consequences were flagged as unintended after #45 merged.
- **Adds** a new `cimas cleanup-merged-prs` subcommand that does only what was actually wanted: delete the branch named by `-b BRANCH` on origin in each repo, **if** the corresponding PR has merged. Open PRs are skipped (their branch is still in use), closed-without-merge PRs are skipped (operator decision territory), repos with no PR for the branch get the branch deleted too (a wave that opened no PR for the repo, e.g. because cimas detected no commits at push time, shouldn't leave a stale branch on origin).

## Usage

After a normal wave run (`cimas push -b cimas-sync-2026-06-27 …` → `cimas open-prs -b cimas-sync-2026-06-27 …`) and after the PRs have merged, run:

```sh
bundle exec exe/cimas cleanup-merged-prs \
  -f /path/to/cimas.yml \
  -r /path/to/cimas-workspace \
  -b cimas-sync-2026-06-27
```

Per-repo log lines name the outcome explicitly:

- `[deleted-merged] metanorma/foo:cimas-sync-... (PR #N)` — happy path, branch removed after merge
- `[deleted-no-pr] metanorma/foo:cimas-sync-...` — branch existed without a PR, removed
- `[absent] metanorma/foo:cimas-sync-...` — branch already gone (nothing to do)
- `[skip-open] metanorma/foo:cimas-sync-... (PR #N still open)` — branch in use, left alone
- `[skip-closed] metanorma/foo:cimas-sync-... (PR #N closed without merge)` — operator decision territory, left alone
- `[ERROR] …` — surfaced but doesn't abort the rest of the run

`--dry-run` is honoured (uses the existing `dry_run` helper).

## Permission model

`Octokit::Client#delete_branch` requires only standard `repo` push permission, not admin scope. That's the level of access @opoudjis already has on most metanorma-org repos — yesterday's manual one-shot loop using exactly that mechanism deleted 127 of the wave's branches without admin. No org-wide default change, no admin-grant blocker.

## Status of related artefacts

- `cimas#45`: the code it added is being removed by this PR. The PR itself stays in history; its commentary is still useful context for why this pivot happened.
- `metanorma/ci#304`: the admin-scope ask was premised on `#45` needing it to take effect. Now moot. I'll close it with a comment pointing at this PR.

## Verification

- `ruby -c lib/cimas/cli/command.rb` and `ruby -c exe/cimas` — both pass.
- `bundle exec exe/cimas cleanup-merged-prs --help` — flag schema parses cleanly, all four flags (`-r`, `-f`, `-b`, `-g`) visible.
- End-to-end exercise will be the next cimas wave's cleanup; not invoked in this PR.

🤖
