### PR TITLE
Add cimas release-preflight subcommand (local fail-fast companion to metanorma/ci#313)

### DIFF
--- a/exe/cimas
+++ b/exe/cimas
@@ -20,6 +20,7 @@ Commonly used command are:
    push :              do push changes to repote server
    open-prs :          do PR for Github with hub utility
    cleanup-merged-prs: delete wave branches whose PR has merged (run after merges land)
+   release-preflight:  local fail-fast checks before firing a release workflow
    for-each :          run command for each repo with conditions
 See 'cimas COMMAND --help' for more information on a specific command.
 HELP
@@ -211,6 +212,21 @@ subcommands = {
 
     opts.on("-g GROUP1,GROUP2,GROUPX", Array, "Groups to update") do |groups|
       options['groups'] = groups
+    end
+  end,
+  'release-preflight' => OptionParser.new do |opts|
+    opts.banner = "Usage: cimas release-preflight --repo NAME [options]"
+
+    opts.on("-r REPOS_PATH", "--repo-path=REPOS_PATH", "Repo root dir path") do |path|
+      options['repos_path'] = Pathname.getwd + path
+    end
+
+    opts.on("-f CONFIG_FILE_PATH", "--config-path=CONFIG_FILE_PATH", "Config file path") do |path|
+      options['config_file_path'] = validate_config_path(Pathname.getwd + path)
+    end
+
+    opts.on("--repo NAME", "Target gem repo to preflight (must be in cimas.yml)") do |name|
+      options['target_repo'] = name
     end
   end,
 }

--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -615,6 +615,115 @@ module Cimas
         end
       end
 
+      # Local maintainer-side preflight that mirrors the GHA preflight job in
+      # `metanorma/ci/.github/workflows/rubygems-release.yml`. Runs against a
+      # single repo's workspace clone before the maintainer fires the
+      # `workflow_dispatch` to actually start the release chain. Catches the
+      # cheap, deterministic failure modes (bundle resolve, gemspec errors,
+      # missing credentials, already-published version) in ~30 sec locally,
+      # so the maintainer never commits to the 2+ hour chain on a release
+      # that was going to fail.
+      #
+      # Companion to the GHA-side preflight introduced in metanorma/ci PR #313.
+      # Both protect against the same class of failures; the GHA preflight
+      # protects every release attempt automatically, this one protects the
+      # maintainer who runs it before firing.
+      def release_preflight
+        repo_name = config['target_repo']
+        if repo_name.nil? || repo_name.empty?
+          raise OptionParser::MissingArgument, "Missing --repo <name>"
+        end
+
+        repo = repo_by_name(repo_name)
+        if repo.nil?
+          raise "[ERROR] #{repo_name} is not in cimas.yml. Run with --config-path pointing at the correct config."
+        end
+
+        repo_dir = File.join(repos_path, repo_name)
+        unless File.exist?(repo_dir) && File.exist?(File.join(repo_dir, '.git'))
+          raise "[ERROR] #{repo_name} is not present in #{repos_path}. Run `cimas setup` first."
+        end
+
+        puts "=== cimas release-preflight: #{repo_name} ==="
+        puts "    workspace: #{repo_dir}"
+        puts ""
+
+        failures = []
+
+        Dir.chdir(repo_dir) do
+          puts "[1/4] Fresh bundle install (Gemfile.lock removed first)..."
+          File.delete('Gemfile.lock') if File.exist?('Gemfile.lock')
+          unless system('bundle install --jobs 4 --retry 3')
+            failures << 'bundle install'
+            puts "    ✗ bundle install failed"
+          else
+            puts "    ✓ bundle install succeeded"
+          end
+          puts ""
+
+          puts "[2/4] Gem build (validates gemspec)..."
+          gemspec_file = Dir['*.gemspec'].first
+          if gemspec_file.nil?
+            puts "    ⚠️  No .gemspec file found in repo root; skipping gem build check"
+          else
+            if system("gem build #{gemspec_file}")
+              puts "    ✓ gem build succeeded"
+              Dir['*.gem'].each { |f| File.delete(f) }
+            else
+              failures << 'gem build'
+              puts "    ✗ gem build failed"
+            end
+          end
+          puts ""
+
+          puts "[3/4] Verify publish credentials available..."
+          creds_path = File.expand_path('~/.gem/credentials')
+          if File.exist?(creds_path)
+            puts "    ✓ ~/.gem/credentials present (API-key publish path viable)"
+          elsif ENV['RUBYGEMS_API_KEY'] && !ENV['RUBYGEMS_API_KEY'].empty?
+            puts "    ✓ RUBYGEMS_API_KEY env var present"
+          else
+            puts "    ⚠️  No ~/.gem/credentials and no RUBYGEMS_API_KEY env var."
+            puts "        OIDC Trusted Publishing may still work in CI, but local `gem push` will fail."
+            puts "        Configure ~/.gem/credentials if you intend to publish from this machine."
+          end
+          puts ""
+
+          puts "[4/4] Version awareness..."
+          if gemspec_file
+            gem_name = `ruby -e "puts Gem::Specification.load('#{gemspec_file}').name"`.strip
+            gem_version = `ruby -e "puts Gem::Specification.load('#{gemspec_file}').version.to_s"`.strip
+            remote_list = `gem list --remote --exact --version "#{gem_version}" "#{gem_name}" 2>/dev/null`
+            if remote_list.include?("#{gem_name} (#{gem_version})")
+              puts "    ℹ️  #{gem_name} #{gem_version} is already on rubygems.org"
+              puts "        With next_version=skip, the idempotent guard will skip the actual gem push."
+              puts "        If you intended to ship NEW code, fire with next_version=patch (or major/minor)."
+            else
+              puts "    ✓ #{gem_name} #{gem_version} is NOT yet on rubygems — clean to publish"
+              latest_list = `gem list --remote --exact "#{gem_name}" 2>/dev/null`
+              if latest_match = latest_list.match(/#{Regexp.escape(gem_name)} \(([0-9.]+)/)
+                puts "        Latest published: #{gem_name} #{latest_match[1]}"
+              else
+                puts "        (No previous public version found.)"
+              end
+            end
+          else
+            puts "    (skipped — no gemspec to identify)"
+          end
+          puts ""
+        end
+
+        puts "=== Result ==="
+        if failures.empty?
+          puts "✓ All preflight checks passed for #{repo_name}."
+          puts "  Safe to fire: gh workflow run release.yml --repo metanorma/#{repo_name} --field next_version=patch"
+        else
+          puts "✗ Preflight FAILED for #{repo_name}: #{failures.join(', ')}"
+          puts "  Do NOT fire the release workflow until the failures above are fixed."
+          exit 1
+        end
+      end
+
       def for_each
         sanity_check
         cmd = shell_cmd


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/309
Refs https://github.com/metanorma/ci/pull/313

## Summary

Adds `cimas release-preflight --repo NAME` subcommand — a local maintainer-side companion to the GHA preflight job that just landed in `metanorma/ci#313`. Runs the same cheap, deterministic fail-fast checks against a workspace clone in ~30 seconds, so the maintainer never commits to the 2+ hour GHA release chain on a release that was going to fail.

## Usage

```sh
bundle exec exe/cimas release-preflight \
  --repo metanorma-cli \
  -f /path/to/metanorma/ci/cimas-config/cimas.yml \
  -r /path/to/cimas-wd
```

## What it checks

Mirrors the four checks in the GHA-side preflight (`metanorma/ci:rubygems-release.yml` preflight job):

| Check | Hard fail? | What it catches |
|---|---|---|
| Fresh `bundle install` (with `Gemfile.lock` removed) | Yes | Dep resolution failures — the v1.16.6 case (`Bundler::GemNotFound: metanorma-nist`) |
| `gem build <gemspec>` | Yes | Gemspec syntax errors, missing files, invalid `required_ruby_version`, bad metadata |
| Verify publish credentials available (`~/.gem/credentials` or `RUBYGEMS_API_KEY` env var) | No (warns only — OIDC may still work in CI) | Missing local rubygems credentials when local publish is intended |
| Version awareness — query rubygems for the current gemspec version | No (informational) | Flags when the current version is already published (re-publish would idempotent-skip); reports latest published version |

On all-pass: exits 0 with a green summary + the recommended `gh workflow run release.yml ...` command to fire. On any hard failure: exits 1 with a clear "DO NOT fire the release workflow" message.

## Relationship to GHA preflight (`metanorma/ci#313`)

Complementary, not duplicative — they protect against the same class of failures but at different layers:

- **GHA preflight** runs automatically on every `workflow_dispatch` invocation, protects every release attempt org-wide, catches issues that reproduce on a fresh GHA runner.
- **`cimas release-preflight`** runs locally on the maintainer's machine when they choose, protects against committing to the 2-hour chain at all, catches local-environment issues (credentials, local gem cache state) that wouldn't reproduce on a runner.

A maintainer who runs `cimas release-preflight` and sees all green can fire the GHA workflow with confidence. A maintainer who forgets to run it is still protected by the GHA-side preflight catching the same issues 90 seconds in.

## Verification

```sh
ruby -c lib/cimas/cli/command.rb     # Syntax OK
ruby -c exe/cimas                     # Syntax OK
bundle exec exe/cimas release-preflight --help
# Usage: cimas release-preflight --repo NAME [options]
#     -r, --repo-path=REPOS_PATH       Repo root dir path
#     -f, --config-path=...            Config file path
#         --repo NAME                  Target gem repo to preflight (must be in cimas.yml)
```

End-to-end exercise will be the next gem release attempt: run `cimas release-preflight --repo metanorma-cli` against the cimas-wd, observe results, then fire the actual workflow if green.

🤖
