### PR TITLE
patches: distinguish pattern-not-present (WARNING) from already-at-target (INFO) (closes #49 Bug 3)

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -195,10 +195,24 @@ module Cimas
             matched.each do |file_path|
               rel_path = file_path.sub(/\A#{Regexp.escape(repo_dir)}\/?/, '')
               original = File.read(file_path)
-              updated = original.gsub(find_regex, replacement)
+              # Distinguish two cases that previously both logged the same
+              # misleading "pattern did not match, file unchanged" warning
+              # (see metanorma/cimas#49 Bug 3):
+              #   - `find` regex doesn't appear in the file at all (the line
+              #     this patch wants to update is genuinely absent — e.g. a
+              #     gemspec with no `required_ruby_version` line, the NOVER
+              #     case). WARNING-level: maintainer may want to add the line.
+              #   - `find` matches but `gsub` produces identical text (the
+              #     file is already at the target value). INFO-level: this is
+              #     a normal idempotent no-op, not a problem.
+              unless find_regex.match?(original)
+                puts "[WARNING] Patch '#{patch_name}' on #{repo_name}:#{rel_path}: pattern not present in file (line absent — consider whether the patch should also handle insertion)."
+                next
+              end
 
+              updated = original.gsub(find_regex, replacement)
               if original == updated
-                puts "[WARNING] Patch '#{patch_name}' on #{repo_name}:#{rel_path}: pattern did not match, file unchanged."
+                puts "[INFO] Patch '#{patch_name}' on #{repo_name}:#{rel_path}: already at target value, no-op."
                 next
               end
 


### PR DESCRIPTION
Closes https://github.com/metanorma/cimas/issues/49 (Bug 3)

## Summary

Distinguishes two genuinely-different cases that previously both logged the same misleading `pattern did not match, file unchanged` warning in `apply_patches`:

1. **Pattern not present in file.** The line the patch wants to update is genuinely absent from the file (e.g. a gemspec with no `required_ruby_version` line — the NOVER case surfaced in tonight's wave on `csa-ccm-tools/csa-ccm.gemspec`). Now logged at **WARNING** level with a clearer message and a hint that the patch should perhaps handle insertion.
2. **Already at target value, no-op.** The regex did match, but `gsub` produced identical text because the file is already at the target value (e.g. a gemspec already at `>= 3.3.0`). Now logged at **INFO** level — this is a normal idempotent no-op, not a problem.

## Why

`gsub` (and `gsub!`) return identical-content / nil in BOTH cases, so the prior code couldn't distinguish:

```ruby
updated = original.gsub(find_regex, replacement)
if original == updated
  puts "[WARNING] Patch ... pattern did not match, file unchanged."
  next
end
```

That conflated:

- "the patch wants to change `s.required_ruby_version` but the file has no such line at all" (a real concern — maintainer may need to either add the line manually or extend the patch to handle insertion)
- "the patch wants to change `s.required_ruby_version` to `>= 3.3.0` but the file already says `>= 3.3.0`" (totally fine, this is idempotency)

Tonight's wave surfaced both classes on similar files (e.g. `metanorma.gemspec` already at 3.3 vs `csa-ccm-tools/csa-ccm.gemspec` genuinely missing the line), making it impossible from the log to tell which was happening where.

## What this PR does

Splits the single equality check into a regex-presence check first, then an idempotency check:

```ruby
unless find_regex.match?(original)
  puts "[WARNING] Patch ... pattern not present in file (line absent — consider whether the patch should also handle insertion)."
  next
end

updated = original.gsub(find_regex, replacement)
if original == updated
  puts "[INFO] Patch ... already at target value, no-op."
  next
end
```

The WARNING is preserved (severity unchanged) for the genuine NOVER case; the no-op case gets downgraded to INFO because it's a normal idempotency result.

Comment block in the method names the originating issue so future maintainers don't merge the two cases back together.

## Backward compatibility

Log-message text changed but no API change. Existing callers see clearer logs.

## Verification

`ruby -c` syntax check passes. The smoke shape:

- Repo where the gemspec is already at the target value → `[INFO] ... already at target value, no-op.`
- Repo where the gemspec has no `required_ruby_version` line → `[WARNING] ... pattern not present in file ...`
- Repo where the regex matches and the substitution differs → no log entry; file modified as before.

🤖
