### PR TITLE
open-prs: add --supersede-stale flag (refs metanorma/ci#300 Gap 4)

### DIFF
--- a/exe/cimas
+++ b/exe/cimas
@@ -191,6 +191,10 @@ subcommands = {
     opts.on("-g GROUP1,GROUP2,GROUPX", Array, "Groups to update") do |groups|
       options['groups'] = groups
     end
+
+    opts.on("--supersede-stale", "When opening a PR, detect any pre-existing open PRs on the same repo whose head branch starts with 'cimas-sync-' (i.e. previous wave PRs that never merged), label them 'superseded-by-#N' (where N is the new PR number), and post a comment linking the new PR. Does NOT auto-close the old PRs — the reviewer keeps authority over the close decision. The new PR's body is prepended with a 'Supersedes #X, #Y' line. See metanorma/ci#300 Gap 4.") do |_|
+      options['supersede_stale'] = true
+    end
   end,
   'for-each' => OptionParser.new do |opts|
     opts.banner = "Usage: cimas sync [options]"

--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -468,6 +468,30 @@ module Cimas
           g = Git.open(repo_dir)
           github_slug = git_remote_to_github_name(repo.remote)
 
+          # --supersede-stale: detect prior open cimas-sync-* PRs on this repo.
+          # See metanorma/ci#300 Gap 4. Cheaper-version (no strict-superset
+          # check): we label-and-comment-but-do-not-close the old PRs, letting
+          # the reviewer keep authority over the close decision. The new PR's
+          # body is prepended with a "Supersedes #X, #Y" note so the reviewer
+          # sees the full picture in the most recent PR.
+          stale_prs = []
+          if options['supersede_stale']
+            begin
+              stale_prs = github_client.pull_requests(github_slug, state: 'open').select do |stale|
+                stale.head.ref.start_with?('cimas-sync-') && stale.head.ref != branch
+              end
+            rescue Octokit::Error => e
+              puts "[WARNING] #{github_slug}: could not list open PRs for --supersede-stale (#{e.message}); proceeding without."
+              stale_prs = []
+            end
+          end
+          final_body = if stale_prs.any?
+                         supersede_list = stale_prs.map { |p| "##{p.number}" }.join(", ")
+                         "_Supersedes #{supersede_list} from prior cimas-sync waves._\n\n#{body}"
+                       else
+                         body
+                       end
+
           dry_run("Opening GitHub PR: #{github_slug}, branch #{repo.branch} <- #{branch}, message '#{message}'") do
             puts "Opening GitHub PR: #{github_slug}, branch #{repo.branch} <- #{branch}, message '#{message}'"
 
@@ -477,11 +501,29 @@ module Cimas
                 repo.branch,
                 branch,
                 message,
-                body,
+                final_body,
               )
               number = pr['number']
 
               github_client.add_labels_to_an_issue(github_slug, number, ['automerge']) if add_auto_merge_label
+
+              # Label-and-comment-but-don't-close the superseded PRs (Gap 4 cheaper).
+              stale_prs.each do |stale|
+                begin
+                  github_client.add_labels_to_an_issue(github_slug, stale.number, ["superseded-by-##{number}"])
+                  github_client.add_comment(
+                    github_slug,
+                    stale.number,
+                    "Superseded by ##{number} from a later cimas-sync wave (`#{branch}`). " \
+                    "This PR was **not auto-closed** by cimas — the reviewer keeps authority over the close decision. " \
+                    "Close after merging ##{number}, or rebase this branch onto something else if part of its content should still be preserved. " \
+                    "(metanorma/ci#300 Gap 4)"
+                  )
+                  puts "  superseded #{github_slug}\##{stale.number} (labelled + commented)"
+                rescue Octokit::Error => e
+                  puts "  [WARNING] could not label/comment supersede on #{github_slug}\##{stale.number}: #{e.message}"
+                end
+              end
 
               puts "PR #{github_slug}\##{number} created"
 


### PR DESCRIPTION
Implements [`metanorma/ci#300`](https://github.com/metanorma/ci/issues/300) Gap 4 (cheaper variant per the [proposal comment](https://github.com/metanorma/ci/issues/300#issuecomment-4832465285)).

## Summary

Adds a `--supersede-stale` opt-in flag to `cimas open-prs`. When set:

1. Before opening each new PR, lists existing open PRs on the same repo whose head branch starts with `cimas-sync-` (i.e. previous wave PRs that never merged).
2. Prepends a `_Supersedes #X, #Y from prior cimas-sync waves._` line to the new PR's body, naming the superseded PRs.
3. After the new PR is opened, **labels** each superseded PR with `superseded-by-#N` (where N is the new PR's number) and **posts a comment** linking the new PR.
4. **Does NOT auto-close** the superseded PRs — the reviewer keeps authority over the close decision.

## Why

`cimas open-prs` waves opened against repos where a previous wave's PR is still open produce a stack of overlapping PRs that nobody can sensibly review. Without intervention the stack only grows — observed pattern: ~2-week delays on active-maintainer repos, multi-month delays on inactive ones, producing multi-PR stacks where every wave's PR is 90% of the next.

The cheaper Gap-4 design (vs. the full strict-superset gate) intentionally skips the diff-superset check. Trade-off:

- ✅ Drops the gate's complexity and edge cases (force-pushes, divergent histories).
- ✅ Label-and-comment-but-don't-close behaviour means the worst-case bad outcome is "extra labels on PRs", not data loss.
- ❌ Doesn't distinguish strict-superset waves (where the new PR contains everything in the old) from different-intent waves (where they should stay parallel).

For most maintainers most of the time, the cheaper version is enough — the label and comment make the relationship visible and let the reviewer make the close call. A future PR can layer the strict-superset gate on top if needed.

## Worked example

Imagine `metanorma/some-gem` has PR `#42` open from `cimas-sync-2026-06-15` (4 files changed, never merged because the maintainer was OOO). A new wave `cimas-sync-2026-06-29` runs against the same repo with `--supersede-stale`:

```
$ cimas open-prs --supersede-stale \
    -b cimas-sync-2026-06-29 \
    -m "Cimas sync 2026-06-29: ..." \
    --body-file /tmp/wave-body.md \
    -g processor
```

The new PR (say `#48`) gets a body prefixed with:

> *Supersedes #42 from prior cimas-sync waves.*
>
> Refs https://github.com/metanorma/ci/issues/274
>
> ... (the rest of /tmp/wave-body.md)

`#42` gets:

1. Label `superseded-by-#48`
2. A new comment:
   > Superseded by #48 from a later cimas-sync wave (`cimas-sync-2026-06-29`). This PR was **not auto-closed** by cimas — the reviewer keeps authority over the close decision. Close after merging #48, or rebase this branch onto something else if part of its content should still be preserved. (metanorma/ci#300 Gap 4)

The reviewer can now:

- Merge `#48` and close `#42` (the common case)
- Rebase part of `#42` onto something else if some content was unique
- Ignore the relationship and triage both — the comment doesn't force a decision

## What this PR does NOT do

- Doesn't auto-close superseded PRs (deliberate — leaves authority with the reviewer).
- Doesn't do strict-superset diff checking (deferred to a possible follow-up if useful).
- Doesn't operate on closed/merged PRs (the `state: 'open'` filter excludes them).
- Doesn't supersede the new wave's own branch (`stale.head.ref != branch` excludes it).
- Doesn't error if the GitHub API call fails — falls back to "proceed without supersede" with a `[WARNING]` so a temporary API hiccup doesn't abort the whole wave.

## Backward compatibility

The flag is **opt-in**. Without `--supersede-stale`, `cimas open-prs` behaves exactly as before. Existing scripts and workflows continue to work unchanged.

## Verification

```sh
$ bundle exec exe/cimas open-prs --help
...
    --supersede-stale            When opening a PR, detect any pre-existing open PRs on the same repo whose head branch starts with 'cimas-sync-' ...
```

Ruby syntax check: `Syntax OK` on both `exe/cimas` and `lib/cimas/cli/command.rb`. The next cimas-sync wave with `--supersede-stale` will exercise the flag in anger.

## Linked

- [`metanorma/ci#300`](https://github.com/metanorma/ci/issues/300) Gap 4 — cheaper variant per [the proposal](https://github.com/metanorma/ci/issues/300#issuecomment-4832465285).
- Companion fixes already landed: [`cimas#50`](https://github.com/metanorma/cimas/pull/50) (`--body-file`), [`cimas#51`](https://github.com/metanorma/cimas/pull/51) (distinguish patches warnings), [`metanorma/ci#324`](https://github.com/metanorma/ci/pull/324) (patches regex relax).

🤖
