### PR TITLE
open-prs: filter token user out of reviewers (closes #7)

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -447,6 +447,26 @@ module Cimas
         # `cimas open-prs` before any PR could be created.
         assignees = Array(config['assignees']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
         reviewers = Array(config['reviewers']).flat_map { |x| x.is_a?(String) ? x.split(',') : x }
+
+        # GitHub rejects self-review requests with HTTP 422
+        # "Review cannot be requested from pull request author."
+        # The rescue path below in the request-review block previously caught
+        # this and skipped the entire request, dropping the OTHER valid
+        # reviewers as a side-effect. Pre-filter the token user out so the
+        # remaining reviewers still get requested. (#7)
+        begin
+          token_user = github_client.user.login
+          if reviewers.include?(token_user)
+            puts "[INFO] open-prs: excluding token user " \
+                 "'#{token_user}' from reviewers (cannot self-review)"
+            reviewers = reviewers.reject { |r| r == token_user }
+          end
+        rescue Octokit::Error => e
+          puts "[WARNING] open-prs: could not resolve token user " \
+               "for self-review filter (#{e.message}); " \
+               "proceeding with reviewers as configured"
+        end
+
         cooldown_count = config['cooldown_count']
         cooldown_time = config['cooldown_time']
 


### PR DESCRIPTION
Closes https://github.com/metanorma/cimas/issues/7

## Summary

When the configured `reviewers` list contains the same GitHub handle the cimas token authenticates as (i.e. the user who is *opening* the PRs), the GitHub API rejects the review request with HTTP 422 `Review cannot be requested from pull request author.`. The pre-existing `rescue` path caught this case and `next`ed out of the whole review-request block for that PR — meaning **the other valid reviewers in the same list were silently dropped too**.

Per the original ticket body: *"A first call should be done in the beginning so the current user gets rejected. The remaining `reviewers` should still be added to the PR."*

## Change

In `open_prs`, after the `reviewers` array is built, resolve the token user (`github_client.user.login`) once and filter them out of `reviewers` before iterating PRs. The `rescue Octokit::Error` block keeps the request-review path working when the user resolution fails for any reason (network, token scope), so behaviour is no-worse-than-before on those edge cases.

Two log lines:

- `[INFO] open-prs: excluding token user '<handle>' from reviewers (cannot self-review)` — only emitted when the filter actually removes someone.
- `[WARNING] open-prs: could not resolve token user for self-review filter (<err>); proceeding with reviewers as configured` — emitted only if `github_client.user.login` itself raises.

## Why not handle this in the rescue instead

The rescue path can't tell which reviewer in the batch was the self-author from the error message alone, and the GitHub API doesn't accept the request partially — it's all-or-nothing per call. Pre-filtering is the only way to guarantee the remaining reviewers still get requested. The rescue path is left in place as a defensive fallback (e.g. for a future case where a configured reviewer's account changes state).

## Verification

- `ruby -c lib/cimas/cli/command.rb` passes.
- Existing rubocop complexity warnings on `open_prs` are pre-existing (Phase B refactor scope) and not introduced by this patch.
- No spec changes — the existing suite doesn't cover `open_prs` Octokit interactions (Phase B will bring coverage up).

## Scope

Touches only the reviewer-filter block in `open_prs`. No CLI flag changes; no config schema changes; no behaviour change when the token user is *not* in the reviewers list.

🤖
