### PR TITLE
verbose: gate noisy per-repo no-op log lines under --verbose (closes #12)

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -70,7 +70,7 @@ module Cimas
             puts "Git cloning #{repo_name} from #{attribs['remote']}..."
             Git.clone(attribs['remote'], repo_name, path: repos_path)
           else
-            puts "Skip cloning #{repo_name}, #{repo_dir} already exists."
+            puts "Skip cloning #{repo_name}, #{repo_dir} already exists." if verbose
           end
         end
       end
@@ -369,7 +369,7 @@ module Cimas
 
           g = Git.open(repo_dir)
           dry_run("Pushing branch #{push_to_branch} (commit #{g.object('HEAD').sha}) to #{g.remotes.first}:#{repo_name}") do
-            puts "repo.branch #{repo.branch}"
+            puts "repo.branch #{repo.branch}" if verbose
 
             unless keep_changes
               g.checkout(repo.branch)
@@ -383,7 +383,9 @@ module Cimas
                 g.status.added.empty? &&
                 g.status.deleted.empty?
 
-              puts "Skipping commit on #{repo_name}, no changes detected."
+              if verbose
+                puts "Skipping commit on #{repo_name}, no changes detected."
+              end
             else
               puts "Committing on #{repo_name}."
               g.commit_all(commit_message)#, amend: true)


### PR DESCRIPTION
Closes https://github.com/metanorma/cimas/issues/12

## Summary

The `--verbose` / `-v` flag is wired through `exe/cimas` → `options['verbose']` → `Command#verbose`, and previously gated two log lines inside `sync`'s `apply_files` step. In a real cimas-sync wave run against ~187 repos, the dominant noise comes from three other lines that **always** print regardless of `--verbose`:

1. **`Skip cloning #{repo_name}, #{repo_dir} already exists.`** in `setup` — fires once per already-cloned repo, which is ~all 187 in any subsequent setup pass.
2. **`Skipping commit on #{repo_name}, no changes detected.`** in `push` — fires once per repo whose wave-sync was a no-op (typically the majority of any sync wave).
3. **`repo.branch #{repo.branch}`** in `push` — leftover debug print with no surrounding context, always emitted.

Together these dwarf the actually-actionable signal in any wave run. Gating them under `verbose` so the default output shows only state changes (clones, commits, errors) addresses the ticket's "the option is supported but doesn't currently do anything" complaint — the option already had narrow coverage in `apply_files`; this expands it to the three high-noise points where it materially helps.

## Change

Three small gates in `lib/cimas/cli/command.rb`:

```diff
-          else
-            puts "Skip cloning #{repo_name}, #{repo_dir} already exists."
+          else
+            puts "Skip cloning #{repo_name}, #{repo_dir} already exists." if verbose
           end
```

```diff
           dry_run("Pushing branch #{push_to_branch}...") do
-            puts "repo.branch #{repo.branch}"
+            puts "repo.branch #{repo.branch}" if verbose
```

```diff
             if g.status.changed.empty? && ...
-              puts "Skipping commit on #{repo_name}, no changes detected."
+              if verbose
+                puts "Skipping commit on #{repo_name}, no changes detected."
+              end
             else
               puts "Committing on #{repo_name}."
```

## Effect on output

- **Without `-v`** (default): you see what changed — clones that ran, commits that landed, PRs that opened, warnings, errors. No per-repo no-op chatter.
- **With `-v`**: you see all of the above plus per-repo no-op confirmations, useful for verifying iteration coverage during debugging or first-time wave runs.

## What this does NOT do

- Doesn't refactor the broader logging surface — Phase B is doing the comprehensive autoload + OOP/MECE pass on `Cli::Command` and will revisit logging holistically (per cimas Phase B scope in the cimas-revival SSOT).
- Doesn't change `puts` calls that are already operational signals (warnings, errors, state changes). Those stay unconditional.
- Doesn't introduce a `verbose_puts` helper — the inline `if verbose` pattern matches the two pre-existing call sites at lines 145 and 163, keeping the diff minimal and consistent.

## Verification

- `ruby -c lib/cimas/cli/command.rb` passes.
- Existing rubocop complexity warnings on `push` are pre-existing (Phase B refactor scope) and not introduced by this patch.

🤖
