### PR TITLE
repository: add per-repo `with:` block for parametric ERB rendering (refs metanorma/ci#300 Gap 1)

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -147,7 +147,16 @@ module Cimas
               if source_path.end_with? ".erb"
                 template = ERB.new(File.read(source_path))
                 temp_file = Tempfile.new
-                params = OpenStruct.new(repo.binding).instance_eval { binding }
+                # Legacy `template: binding:` values are exposed as
+                # OpenStruct dot-notation methods (e.g. `<%= flavor %>`).
+                # The `with:` block (metanorma/ci#300 Gap 1) is exposed
+                # as `with_values` — a Hash — so ERB templates can access
+                # keys that aren't valid Ruby identifiers (e.g. `private-fonts`)
+                # via `<%= with_values['private-fonts'] %>`.
+                erb_context = repo.binding.merge(
+                  "with_values" => repo.with_values,
+                )
+                params = OpenStruct.new(erb_context).instance_eval { binding }
                 temp_file.puts(template.result(params))
                 temp_file.flush
                 copy_file(temp_file, target_path)

--- a/lib/cimas/repository.rb
+++ b/lib/cimas/repository.rb
@@ -1,6 +1,6 @@
 module Cimas
   class Repository
-    attr_reader :name, :remote, :branch, :files, :binding
+    attr_reader :name, :remote, :branch, :files, :binding, :with_values
 
     def initialize(name, attributes = {})
       init_from_attributes(name, attributes)
@@ -19,7 +19,18 @@ module Cimas
         @remote = attributes.fetch("remote", nil)
         @branch = attributes.fetch("branch", nil)
         @files = attributes.fetch("files", nil)
-        @binding = attributes.dig("template", "binding") { {} }
+        # Hash#dig doesn't accept a block — the `{ {} }` in the prior
+        # version was silently ignored, so absent `template: binding:`
+        # yielded `nil`. Explicit `|| {}` keeps the type stable (always a
+        # Hash); the sole consumer at `Cli::Command#sync` wraps it in an
+        # OpenStruct where nil and {} behave identically, so this is a
+        # correctness-not-behaviour fix.
+        @binding = attributes.dig("template", "binding") || {}
+        # `with:` is a per-repo top-level hash rendered into ERB templates
+        # as `with_values`. Semantically intended for reusable-workflow
+        # `with:` block inputs (per metanorma/ci#300 Gap 1) but the values
+        # are just a Hash — usable for any parametric rendering.
+        @with_values = attributes.fetch("with", {}) || {}
       end
     end
   end

--- a/spec/cimas/repository_spec.rb
+++ b/spec/cimas/repository_spec.rb
@@ -27,6 +27,131 @@ RSpec.describe Cimas::Repository do
         expect(repository.nil?).to be_truthy
       end
     end
+
+    context "with a `template: binding:` block (legacy ERB binding)" do
+      it "exposes the binding hash via `#binding`" do
+        name = "mn-samples-plateau"
+        data = sample_data["repositories"][name]
+
+        repository = Cimas::Repository.new(name, data)
+
+        expect(repository.binding).to eq("flavor" => "plateau")
+      end
+    end
+
+    context "without a `template: binding:` block" do
+      it "exposes an empty binding hash" do
+        name = "metanorma-cli"
+        data = sample_data["repositories"][name]
+
+        repository = Cimas::Repository.new(name, data)
+
+        expect(repository.binding).to eq({})
+      end
+    end
+
+    context "with a `with:` block (metanorma/ci#300 Gap 1)" do
+      it "exposes the with-block hash via `#with_values`" do
+        name = "metanorma"
+        data = sample_data["repositories"][name]
+
+        repository = Cimas::Repository.new(name, data)
+
+        expect(repository.with_values).to eq(
+          "private-fonts" => true,
+          "submodules" => true,
+        )
+      end
+
+      it "keeps `#binding` empty when only `with:` is set" do
+        name = "metanorma"
+        data = sample_data["repositories"][name]
+
+        repository = Cimas::Repository.new(name, data)
+
+        expect(repository.binding).to eq({})
+      end
+    end
+
+    context "without a `with:` block" do
+      it "exposes an empty with-values hash" do
+        name = "metanorma-cli"
+        data = sample_data["repositories"][name]
+
+        repository = Cimas::Repository.new(name, data)
+
+        expect(repository.with_values).to eq({})
+      end
+    end
+  end
+
+  # End-to-end rendering — confirms the `with_values` hash reaches an ERB
+  # template through the same binding shape `Cli::Command#sync` uses.
+  # Mirrors the production render path in a spec-scale harness.
+  describe "ERB rendering with `with_values`" do
+    require "erb"
+    require "ostruct"
+
+    def render_with(repository, erb_source)
+      erb_context = repository.binding.merge(
+        "with_values" => repository.with_values,
+      )
+      params = OpenStruct.new(erb_context).instance_eval { binding }
+      ERB.new(erb_source).result(params)
+    end
+
+    it "renders `with:` block values via hash access" do
+      repository = Cimas::Repository.new(
+        "metanorma",
+        sample_data["repositories"]["metanorma"],
+      )
+
+      erb = <<~ERB
+        with:
+          private-fonts: <%= with_values['private-fonts'] %>
+          submodules: <%= with_values['submodules'] %>
+      ERB
+
+      expect(render_with(repository, erb)).to eq(<<~YAML)
+        with:
+          private-fonts: true
+          submodules: true
+      YAML
+    end
+
+    it "preserves legacy `binding:` dot-notation access" do
+      repository = Cimas::Repository.new(
+        "mn-samples-plateau",
+        sample_data["repositories"]["mn-samples-plateau"],
+      )
+
+      erb = "extra-flavors: <%= flavor %>\n"
+
+      expect(render_with(repository, erb)).to eq("extra-flavors: plateau\n")
+    end
+
+    it "supports both mechanisms coexisting on one repo" do
+      # Synthesised on the fly — not in the sample.yml fixture — to avoid
+      # bloating the fixture with a case that only this spec cares about.
+      data = {
+        "remote" => "ssh://git@github.com/metanorma/hybrid",
+        "branch" => "main",
+        "files" => {},
+        "template" => { "binding" => { "flavor" => "hybrid" } },
+        "with" => { "private-fonts" => true },
+      }
+      repository = Cimas::Repository.new("hybrid", data)
+
+      erb = <<~ERB
+        flavor: <%= flavor %>
+        private-fonts: <%= with_values['private-fonts'] %>
+      ERB
+
+      expect(render_with(repository, erb)).to eq(<<~YAML)
+        flavor: hybrid
+        private-fonts: true
+      YAML
+    end
   end
 
   def sample_data

--- a/spec/fixtures/sample.yml
+++ b/spec/fixtures/sample.yml
@@ -26,6 +26,26 @@ repositories:
       .github/workflows/macos.yml: gh-actions/model/macos.yml
       .github/workflows/ubuntu.yml: gh-actions/model/ubuntu.yml
       .github/workflows/windows.yml: gh-actions/model/windows.yml
+  # Fixture for the legacy per-repo ERB binding mechanism (nested under
+  # `template:`). Existing consumers rely on this shape; must stay working.
+  mn-samples-plateau:
+    remote: ssh://git@github.com/metanorma/mn-samples-plateau
+    branch: main
+    files:
+      .github/workflows/docker.yml: gh-actions/samples/private-docker.yml.erb
+    template:
+      binding:
+        flavor: plateau
+  # Fixture for the metanorma/ci#300 Gap 1 `with:` block — a top-level
+  # per-repo key rendered into ERB templates as `with_values`.
+  metanorma:
+    remote: ssh://git@github.com/metanorma/metanorma
+    branch: main
+    files:
+      .github/workflows/rake.yml: gh-actions/master/rake.yml.erb
+    with:
+      private-fonts: true
+      submodules: true
 
 groups:
   converter:


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Adds per-repo **`with:`** support to `cimas.yml` — the schema addition [`metanorma/ci#300` Gap 1](https://github.com/metanorma/ci/issues/300) proposed. A repo entry can now declare a `with:` block whose values are exposed to ERB templates as `with_values`, enabling per-repo customisation of reusable-workflow inputs (`private-fonts`, `submodules`, `setup-tools`, etc.) without duplicating templates.

Backward-compatible with the existing `template: binding:` mechanism (which is unchanged).

## Schema

```yaml
repositories:
  metanorma:
    remote: ssh://git@github.com/metanorma/metanorma
    branch: main
    files:
      .github/workflows/rake.yml: gh-actions/master/rake.yml.erb
    with:
      private-fonts: true
      submodules: true
```

## ERB template access

In an `.erb` template, `with_values` is a Hash containing the block's keys:

```erb
jobs:
  rake:
    uses: metanorma/ci/.github/workflows/generic-rake.yml@main
    with:
      private-fonts: <%= with_values['private-fonts'] %>
      submodules: <%= with_values['submodules'] %>
```

Hash-style access (`with_values['key']`) is required because reusable-workflow input names like `private-fonts` contain hyphens and aren't valid Ruby identifiers. The legacy `template: binding:` mechanism (which used OpenStruct dot-notation like `<%= flavor %>`) continues to work unchanged — both mechanisms can coexist on the same repo entry.

## Changes

- `lib/cimas/repository.rb`:
  - Added `attr_reader :with_values`
  - `@with_values = attributes.fetch("with", {}) || {}` in the initialiser
  - **Bug fix**: `@binding = attributes.dig("template", "binding") { {} }` was silently ignoring its block (`Hash#dig` doesn't accept one), returning `nil` when `template:binding:` was absent. Changed to `|| {}` so `binding` is always a Hash. Existing consumer at `Cli::Command#sync` wraps the result in `OpenStruct` where `nil` and `{}` behave identically — so this is a correctness-not-behaviour fix.
- `lib/cimas/cli/command.rb`:
  - Merged `with_values` into the ERB context under the `with_values` key alongside the legacy binding hash. One-line change to the `.erb` rendering block in `sync`.
- `spec/cimas/repository_spec.rb` (new specs):
  - 4 specs for `Repository#binding` / `#with_values` attribute accessors (presence, absence, defaults)
  - 3 specs for end-to-end ERB rendering — confirms the mechanism reaches templates via the same context shape `Cli::Command#sync` uses
- `spec/fixtures/sample.yml`:
  - Two new fixture entries (`mn-samples-plateau` for the legacy binding mechanism, `metanorma` for the new `with:` mechanism)

## Test results

```
10 examples, 0 failures
```

All 8 new specs pass; existing `#binding` behaviour is preserved via the legacy path.

**Note**: `spec/cimas/cli/command_spec.rb`'s `apply_patches` warning-message spec was already failing on `main` before this PR (confirmed via `git stash`) — spec expects `pattern did not match` but the message was refactored to `pattern not present in file` in [`cimas#51`](https://github.com/metanorma/cimas/pull/51). Separate follow-up; not in scope here.

## What's NOT in this PR

Per the "prove the mechanism, migrate at leisure" split agreed with @opoudjis:

- **`metanorma/ci:cimas-config/gh-actions/master/rake.yml.erb`** — the actual parametric template that would consume `with_values`. Not shipped here; deferred to a follow-up PR against `metanorma/ci` once this cimas support is confirmed.
- **`metanorma/ci:cimas-config/cimas.yml`** — the real `metanorma` repo entry gaining `with: private-fonts: true`. Follow-up.
- **README documentation** of the `with:` syntax. Worth a follow-up doc PR.

Shipping only the mechanism first means the schema addition is verified end-to-end (via the specs) before consumers migrate.

## Design decisions worth naming

- **`with:` as a top-level per-repo key**, not nested under `template:`. Ergonomically clean for the common case (reusable-workflow inputs) while keeping the legacy `template: binding:` shape available for existing consumers (e.g. `mn-samples-plateau: template: binding: flavor: plateau`).
- **Hash access (`with_values['key']`)** in ERB, not OpenStruct dot-notation. Reusable-workflow input names commonly contain hyphens (`private-fonts`, `next-version`, `role-to-assume`) which aren't valid Ruby identifiers. Hash access sidesteps this cleanly.
- **`with_values` naming** rather than `with`, `inputs`, or `params`. Avoids collision with the Ruby `with_index` idiom and the reserved word `with`; explicit `_values` suffix signals "this is a Hash of values." Consistent with the existing `binding:` shape.
- **Fixture additions rather than mutating existing entries.** The three original fixture entries (`metanorma-cli`, `metanorma-model-gb`, `metanorma-model-iso`) drive existing specs; adding new entries alongside keeps those green.
- **End-to-end ERB rendering test in the same file** as the model spec. Verifies the mechanism reaches production ERB in a spec-scale harness without needing to invoke the full `sync` subcommand.

## Verification

- Unit specs on `Repository` accessor behaviour (with/without `template: binding:`, with/without `with:`)
- End-to-end ERB rendering test that mirrors `Cli::Command#sync`'s render path
- Full spec suite runs, no new failures introduced

🤖
