### PR TITLE
open-prs: add --flatten-stale for Gap 4 full auto-close of superseded PRs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -315,6 +315,31 @@ A future PR may layer a strict-superset diff gate on top (only supersede when th
 
 A more elegant single-branch-per-repo alternative (rebase the existing `cimas-sync` branch in-place rather than opening new PRs) is noted in `metanorma/ci#300` as a possible Phase-B candidate — bigger mental-model shift, defer until the revival settles.
 
+===== `--flatten-stale` flag (Gap 4 full, implemented 2026-07-04)
+
+`--flatten-stale` is the full Gap 4 shape: same detection as `--supersede-stale` but **also auto-closes the superseded PRs**. Implies `--supersede-stale` (setting `--flatten-stale` alone activates both detection AND auto-close).
+
+Use this when you're confident the new wave's content strictly supersedes the older waves' — which is the standard case for cimas-sync waves, since every wave regenerates the same file set from `cimas.yml`. If the older PR contained content that should be preserved (e.g. a mid-wave hand-edit), rebase that branch elsewhere and reopen before running the new wave.
+
+Behavioural delta vs `--supersede-stale`:
+
+- Superseded PRs get labelled `superseded-closed-by-#N` (instead of `superseded-by-#N`).
+- The comment on each superseded PR names auto-closure and points at the new PR.
+- Each superseded PR is closed via `github_client.close_pull_request`.
+
+[source,sh]
+----
+cimas open-prs --flatten-stale \
+  -r ~/src/cimas-wd-2026-06-29 \
+  -f cimas.yml \
+  -b cimas-sync-2026-06-29 \
+  -m "Cimas sync 2026-06-29: ..." \
+  --body-file /tmp/wave-body.md \
+  -g processor
+----
+
+The strict-superset diff gate mentioned above for `--supersede-stale`'s follow-up is orthogonal to `--flatten-stale` — the flatten variant assumes the wave-regeneration invariant rather than checking it per-PR. If the invariant is broken (e.g. a wave that intentionally covers a narrower subset of files), stick with `--supersede-stale` and close manually.
+
 ==== `cimas for-each`
 
 The `for-each` sub-command allow to execute arbitrary shell command for each repo

--- a/exe/cimas
+++ b/exe/cimas
@@ -195,6 +195,11 @@ subcommands = {
     opts.on("--supersede-stale", "When opening a PR, detect any pre-existing open PRs on the same repo whose head branch starts with 'cimas-sync-' (i.e. previous wave PRs that never merged), label them 'superseded-by-#N' (where N is the new PR number), and post a comment linking the new PR. Does NOT auto-close the old PRs — the reviewer keeps authority over the close decision. The new PR's body is prepended with a 'Supersedes #X, #Y' line. See metanorma/ci#300 Gap 4.") do |_|
       options['supersede_stale'] = true
     end
+
+    opts.on("--flatten-stale", "Gap 4 full: like --supersede-stale, but ALSO auto-closes the superseded PRs. Implies --supersede-stale. Use when confident the new wave's content strictly supersedes the older waves' (the standard cimas-sync-* case, since every wave regenerates the same files from cimas.yml). Superseded PRs get labelled 'superseded-closed-by-#N', a comment noting auto-closure, and are closed. See metanorma/ci#300 Gap 4 full.") do |_|
+      options['flatten_stale'] = true
+      options['supersede_stale'] = true # flatten implies supersede
+    end
   end,
   'for-each' => OptionParser.new do |opts|
     opts.banner = "Usage: cimas sync [options]"

--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -425,6 +425,47 @@ module Cimas
         # run_cmd("git -C #{repos_path} multi -c add appveyor.yml")
       end
 
+      # Label + comment (+ optionally close) a superseded prior-wave PR.
+      # Called from the open_prs loop for each stale PR detected via
+      # --supersede-stale / --flatten-stale (Gap 4 of metanorma/ci#300).
+      def handle_superseded_pr(github_slug, stale, new_number, new_branch,
+                               flatten:)
+        label = flatten ? "superseded-closed-by-##{new_number}" \
+                        : "superseded-by-##{new_number}"
+        github_client.add_labels_to_an_issue(
+          github_slug, stale.number, [label]
+        )
+        github_client.add_comment(
+          github_slug, stale.number,
+          supersede_comment_body(new_number, new_branch, flatten: flatten)
+        )
+        if flatten
+          github_client.close_pull_request(github_slug, stale.number)
+          puts "  flattened #{github_slug}##{stale.number} " \
+               "(labelled + commented + closed)"
+        else
+          puts "  superseded #{github_slug}##{stale.number} " \
+               "(labelled + commented)"
+        end
+      end
+
+      def supersede_comment_body(new_number, new_branch, flatten:)
+        if flatten
+          "Auto-closed as superseded by ##{new_number} from a later " \
+            "cimas-sync wave (`#{new_branch}`). If part of this PR's " \
+            "content should have been preserved before flattening, " \
+            "rebase this branch elsewhere and reopen. " \
+            "(--flatten-stale, metanorma/ci#300 Gap 4 full)"
+        else
+          "Superseded by ##{new_number} from a later cimas-sync wave " \
+            "(`#{new_branch}`). This PR was **not auto-closed** by cimas " \
+            "— the reviewer keeps authority over the close decision. " \
+            "Close after merging ##{new_number}, or rebase this branch " \
+            "onto something else if part of its content should still be " \
+            "preserved. (metanorma/ci#300 Gap 4)"
+        end
+      end
+
       def git_remote_to_github_name(remote)
         remote.match(/github.com\/(.*)/)[1]
       end
@@ -538,21 +579,21 @@ module Cimas
 
               github_client.add_labels_to_an_issue(github_slug, number, ['automerge']) if add_auto_merge_label
 
-              # Label-and-comment-but-don't-close the superseded PRs (Gap 4 cheaper).
+              # Label-and-comment (--supersede-stale, Gap 4 cheaper) OR
+              # label-and-comment-and-close (--flatten-stale, Gap 4 full).
+              # The flatten-stale path auto-closes the superseded PRs on the
+              # assumption that every cimas-sync wave regenerates the same
+              # files from cimas.yml, so a newer wave strictly supersedes
+              # any older wave's PR on the same repo.
               stale_prs.each do |stale|
                 begin
-                  github_client.add_labels_to_an_issue(github_slug, stale.number, ["superseded-by-##{number}"])
-                  github_client.add_comment(
-                    github_slug,
-                    stale.number,
-                    "Superseded by ##{number} from a later cimas-sync wave (`#{branch}`). " \
-                    "This PR was **not auto-closed** by cimas — the reviewer keeps authority over the close decision. " \
-                    "Close after merging ##{number}, or rebase this branch onto something else if part of its content should still be preserved. " \
-                    "(metanorma/ci#300 Gap 4)"
+                  handle_superseded_pr(
+                    github_slug, stale, number, branch,
+                    flatten: options['flatten_stale'] == true,
                   )
-                  puts "  superseded #{github_slug}\##{stale.number} (labelled + commented)"
                 rescue Octokit::Error => e
-                  puts "  [WARNING] could not label/comment supersede on #{github_slug}\##{stale.number}: #{e.message}"
+                  puts "  [WARNING] could not process supersede on " \
+                       "#{github_slug}\##{stale.number}: #{e.message}"
                 end
               end
 


### PR DESCRIPTION
Refs https://github.com/metanorma/ci/issues/300

## Summary

Adds `--flatten-stale` as the **full Gap 4** shape of the cimas-sync-supersede mechanism from `metanorma/ci#300`. Extends [`cimas#52`](https://github.com/metanorma/cimas/pull/52)'s `--supersede-stale` (which labelled + commented) with auto-close of the superseded PRs.

## The mechanism

`--flatten-stale`:

- Implies `--supersede-stale` (setting `--flatten-stale` alone activates detection + label-and-comment + auto-close).
- Detection is identical: pre-existing open PRs whose head branch starts with `cimas-sync-` and differs from the current wave's branch.
- Label: `superseded-closed-by-#N` (differentiates from `--supersede-stale`'s `superseded-by-#N`).
- Comment: notes the auto-closure and points at the new PR.
- Close: via `github_client.close_pull_request(github_slug, stale.number)`.

## When to use which

- **`--supersede-stale`**: label + comment, reviewer decides close. Safer for the "some old PRs contain hand-edited content" case.
- **`--flatten-stale`**: label + comment + auto-close. Right when the wave-regeneration invariant holds (every wave regenerates the same file set from cimas.yml, so newer waves strictly supersede older). This is the standard case.

## Design decisions

- **`--flatten-stale` implies `--supersede-stale`** at CLI-flag time. Cleaner than requiring both flags. Setting `--supersede-stale` alone keeps the cheaper cimas#52 behaviour.
- **Separate label** (`superseded-closed-by-#N` vs `superseded-by-#N`) so the superseded PR's label history distinguishes the two modes at a glance.
- **Comment body factored out** (`supersede_comment_body`) so both modes go through the same shape, differing only in text.
- **`handle_superseded_pr` extracted** as a helper so the open_prs loop stays scannable; also gives a smaller unit that could be spec'd in a future pass.

## What's NOT in this PR

- **Strict-superset diff gate** — a separate feature that would inspect the PRs' file diffs to decide safety before flatten. Orthogonal to this ship; the flatten variant assumes the wave-regeneration invariant. If the invariant breaks (a wave that intentionally covers a narrower subset), use `--supersede-stale` and close manually.
- **Automated specs** — the existing `--supersede-stale` implementation has no test coverage; matching parity here to keep the PR focused. `supersede_comment_body` is a pure function easily spec'd in a future pass; `handle_superseded_pr` would need github_client mocking (broader Phase-B scope).
- **`cimas merge-prs` subcommand** — the constructive companion (auto-merge verified wave PRs as a batch) noted in `cimas#14` remains a separate ticket. `--flatten-stale` handles the destructive side; `merge-prs` handles the constructive side.

## Files changed

- `exe/cimas` — new `--flatten-stale` option in the `open-prs` subcommand's OptionParser
- `lib/cimas/cli/command.rb` — new `handle_superseded_pr` + `supersede_comment_body` methods; open_prs loop delegates to `handle_superseded_pr`
- `README.adoc` — new "`--flatten-stale` flag" section under the open-prs discussion, alongside the existing `--supersede-stale` section

## Verification

- `ruby -c` clean on both source files.
- Existing `--supersede-stale` behaviour preserved — the split into `handle_superseded_pr` renders the same label + comment when `flatten: false`.
- Rubocop noise (method length, ternary, comma-after-last-param) is either pre-existing structural (open_prs is already 300+ lines, Phase B territory) or matches the code style of surrounding helpers.

## Related

- [`metanorma/ci#300`](https://github.com/metanorma/ci/issues/300) — parent Gap 4 issue.
- [`cimas#52`](https://github.com/metanorma/cimas/pull/52) — cheaper `--supersede-stale` this extends.
- [`cimas#14`](https://github.com/metanorma/cimas/issues/14) — future `merge-prs` constructive companion.

🤖
