### PR TITLE
sync: pass trim_mode: '-' to ERB.new so parametric templates render

### DIFF
--- a/lib/cimas/cli/command.rb
+++ b/lib/cimas/cli/command.rb
@@ -145,7 +145,11 @@ module Cimas
               puts "file #{source_path} => #{target_path}" if verbose
 
               if source_path.end_with? ".erb"
-                template = ERB.new(File.read(source_path))
+                # trim_mode: '-' honours <%- ... -%> and <%- ... -%> trim
+                # markers, so templates can render conditional blocks
+                # cleanly without stray blank lines. Backward-compatible:
+                # templates that don't use the '-' markers are unaffected.
+                template = ERB.new(File.read(source_path), trim_mode: "-")
                 temp_file = Tempfile.new
                 # Legacy `template: binding:` values are exposed as
                 # OpenStruct dot-notation methods (e.g. `<%= flavor %>`).


### PR DESCRIPTION
One-line fix discovered mid-sweep: cimas ci#344/#346's parametric .erb templates use `<%- -%>` trim markers. cimas's `ERB.new(File.read(source_path))` call didn't set trim_mode, so those '-' chars fed Ruby as literals → SyntaxError on render.

Fix: `ERB.new(File.read(source_path), trim_mode: '-')`.

Backward-compatible: templates without '-' markers are unaffected. Unblocks the 2026-07-05 sweep.

🤖